### PR TITLE
fix pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ https://github.com/joffreyBerrier/vue-hotel-datepicker/projects/1?fullscreen=tru
 * Review the tooltips when there is periods array #50
 * Display the calendar in full size without input #61
 * Add a range of bookings #65
-
+* Review the pagination on mobile side:
+-- remove pagination with scroll add a button for more smooth
+-- use the same logique on desktop side increment an index and create month only when the index is superior to countOfMobileMonth / countOfDesktopMonth
+* Review some style of mobile calendar
+* Add v-if on when day.belongsToThisMonth === false to avoid 10 day per month load for nothing at all
+* Increase the performance on mobile side
 ------------
 
 ## What I will improve
@@ -328,26 +333,12 @@ periodDates: [
 
 #### `MinimumDuration` with a periodType `weekly-~` equals to a week
 
-### showPrice
-
-- Type: `Boolean`
-- Default: `false`
-
-If set to true, displays a price contains on your periodDates
-
 ### showSingleMonth
 
 - Type: `Boolean`
 - Default: `false`
 
 If set to true, display one month only
-
-### gridStyle
-
-- Type: `Boolean`
-- Default: `true`
-
-**Show** or **hide** a grid around the days
 
 ### positionRight
 
@@ -430,6 +421,19 @@ Example:
 
 ```
 
+### countOfMobileMonth
+
+- Type: `Number`
+- Default: `10`
+
+Number of month you want to show on mobile
+
+### countOfDesktopMonth
+
+- Type: `Number`
+- Default: `2`
+
+Number of month you want to show on desktop
 
 ## API
 ⚠️ In order to open/close the datepicker from an external element, such as a button make sure to set `closeDatepickerOnClickOutside` to false

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,8 @@
           :lastDateAvailable="lastDateAvailable"
           :minNights="minNights"
           :i18n="frFR"
+          :disableCheckoutOnCheckin="true"
+          :periodDates="periodDates"
           @renderNextMonth="renderNextMonth"
         />
       </div>
@@ -143,44 +145,6 @@
       </div>
       <div class="box">
         <h3>
-          Hide grid style
-        </h3>
-        <DatePicker
-          :disabledDates="[
-            '2021-06-15',
-            '2021-06-16',
-            '2021-06-17',
-            '2021-06-18',
-            '2021-06-19',
-            '2021-06-20',
-            '2021-06-21',
-            '2021-07-01',
-            '2021-07-02',
-            '2021-07-03',
-            '2021-07-04',
-            '2021-07-11',
-            '2021-07-12',
-            '2021-07-13',
-            '2021-07-14',
-            '2021-07-15',
-            '2021-07-16',
-            '2021-07-17',
-            '2021-07-18'
-          ]"
-          :format="dateFormat"
-          :lastDateAvailable="lastDateAvailable"
-          :minNights="minNights"
-          :i18n="frFR"
-          :gridStyle="false"
-          :showYear="true"
-          :firstDayOfWeek="1"
-          :disableCheckoutOnCheckin="true"
-          :periodDates="periodDates"
-          @handleCheckIncheckOutHalfDay="handleCheckIncheckOutHalfDay"
-        />
-      </div>
-      <div class="box">
-        <h3>
           Display one month only
         </h3>
         <DatePicker
@@ -235,15 +199,6 @@
         </h3>
         <p>Stop pagination two years later</p>
         <DatePicker :lastDateAvailable="lastDateAvailable" />
-      </div>
-      <div class="box">
-        <h3>Show prices with <strong>periodDates</strong></h3>
-        <DatePicker
-          :showPrice="true"
-          :minNights="minNights"
-          :periodDates="periodDates"
-          @dayClicked="dayClicked"
-        />
       </div>
       <div class="box">
         <h3>

--- a/src/components/BookingBullet.vue
+++ b/src/components/BookingBullet.vue
@@ -2,9 +2,9 @@
   <i class="parent-bullet">
     <i
       v-if="previousBooking && duplicateBookingDates.includes(formatDate)"
-      class="bullet"
       :style="previousBooking.style"
       :class="[
+        'bullet',
         {
           checkInCheckOut: duplicateBookingDates.includes(formatDate)
         }
@@ -21,9 +21,9 @@
           (currentBooking.checkInDate === formatDate ||
             currentBooking.checkOutDate === formatDate)
       "
-      class="bullet"
       :style="currentBooking.style"
       :class="[
+        'bullet',
         {
           checkIn: currentBooking.checkInDate === formatDate,
           checkOut: currentBooking.checkOutDate === formatDate
@@ -32,8 +32,8 @@
     />
     <i
       v-if="currentBooking"
-      class="pipe"
       :class="[
+        'pipe',
         {
           checkIn: currentBooking.checkInDate === formatDate,
           checkOut: currentBooking.checkOutDate === formatDate

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -1,10 +1,9 @@
 <template>
   <div
-    class="datepicker__input"
+    :class="['datepicker__input', inputClass]"
     @click="toggleDatepicker"
     @keyup.enter.stop.prevent="toggleDatepicker"
     data-qa="datepickerInput"
-    :class="inputClass"
     :tabindex="tabIndex"
   >
     {{ inputDate ? inputDate : i18n[inputDateType] }}

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -17,6 +17,10 @@ export default {
       type: Boolean,
       required: true
     },
+    i18n: {
+      type: Object,
+      required: true
+    },
     inputDate: {
       type: String,
       default: null
@@ -31,10 +35,6 @@ export default {
     },
     toggleDatepicker: {
       type: Function,
-      required: true
-    },
-    i18n: {
-      type: Object,
       required: true
     }
   },

--- a/src/components/DatePicker/index.scss
+++ b/src/components/DatePicker/index.scss
@@ -59,6 +59,10 @@ $extra-small-screen: '(max-width: 23em)';
   align-items: center;
   justify-content: space-between;
   padding: 1.5rem 2.5rem;
+
+  @include device($up-to-tablet) {
+    padding: 1rem;
+  }
 }
 .container-square {
   display: grid;
@@ -71,16 +75,21 @@ $extra-small-screen: '(max-width: 23em)';
 .datepicker__button-paginate--mobile {
   width: 100%;
   border: 0;
-  height: 60px;
-  line-height: 60px;
+  height: 50px;
+  line-height: 50px;
   border-top: 1px solid rgba(245, 247, 248, 100);
   background: white;
   margin-top: 2rem;
   position: relative;
 
+  &--top {
+    margin: 0;
+    transform: rotate(180deg);
+  }
+
   .arrow {
-    width: 6vmin;
-    height: 6vmin;
+    width: 4vmin;
+    height: 4vmin;
     box-sizing: border-box;
     position: absolute;
     left: 50%;
@@ -93,7 +102,7 @@ $extra-small-screen: '(max-width: 23em)';
       height: 100%;
       border-width: .8vmin .8vmin 0 0;
       border-style: solid;
-      border-color: $black;
+      border-color: $primary-color;
       transition: .2s ease;
       display: block;
       transform-origin: 100% 0;
@@ -107,7 +116,7 @@ $extra-small-screen: '(max-width: 23em)';
       height: 100%;
       border-width: 0 .8vmin 0 0;
       border-style: solid;
-      border-color: $black;
+      border-color: $primary-color;
       transform-origin: 100% 0;
       transition:.2s ease;
     }
@@ -736,8 +745,9 @@ $extra-small-screen: '(max-width: 23em)';
       height: 0;
       opacity: 0;
       visibility: hidden;
-      padding: 0 15px;
-      border: 1px solid #d7d9e2;
+      padding: 0 1rem;
+      border-bottom: 1px solid #d7d9e2;
+      border-top: 1px solid #d7d9e2;
       font-size: 14px;
       line-height: 1.4;
       transition: all ease .2s;

--- a/src/components/DatePicker/index.scss
+++ b/src/components/DatePicker/index.scss
@@ -73,9 +73,9 @@ $extra-small-screen: '(max-width: 23em)';
   border: 0;
   height: 60px;
   line-height: 60px;
-  border: 1px solid #eaeaea;
+  border-top: 1px solid rgba(245, 247, 248, 100);
   background: white;
-  box-shadow: 0 5px 20px 5px rgb(0 0 0 / 8%);
+  margin-top: 2rem;
   position: relative;
 
   .arrow {
@@ -272,6 +272,10 @@ $extra-small-screen: '(max-width: 23em)';
     justify-content: space-between;
     width: 100%;
     height: 100%;
+
+    @include device($up-to-tablet) {
+      height: 50px
+    }
 
     &--no-border.datepicker__dummy-wrapper {
       border: 0;
@@ -533,12 +537,13 @@ $extra-small-screen: '(max-width: 23em)';
 
     @include device($up-to-tablet) {
       padding: 0;
+      height: 100%;
     }
   }
 
   .show-tooltip {
     .datepicker__months {
-      height: calc(100vh - 140px);
+      height: calc(100% - 140px);
     }
     .datepicker__tooltip--mobile {
       height: auto;
@@ -557,7 +562,7 @@ $extra-small-screen: '(max-width: 23em)';
     }
 
     @include device($up-to-tablet) {
-      height: calc(100vh - 90px);
+      height: calc(100% - 90px);
       overflow-y: scroll;
       transition: all ease .2s;
     }
@@ -646,7 +651,7 @@ $extra-small-screen: '(max-width: 23em)';
       height: 40px;
       align-items: center;
       margin: 0;
-      box-shadow: 0px 8px 12px 0px rgba($black, .1);
+      border-bottom: 1px solid rgba(245, 247, 248, 100);
     }
   }
 
@@ -823,4 +828,10 @@ $extra-small-screen: '(max-width: 23em)';
       width: calc(50% - 19px);
     }
   }
+}
+
+
+// Tailwind style
+.h-full {
+  height: 100%
 }

--- a/src/components/DatePicker/index.scss
+++ b/src/components/DatePicker/index.scss
@@ -562,8 +562,9 @@ $extra-small-screen: '(max-width: 23em)';
     }
 
     @include device($up-to-tablet) {
-      height: calc(100% - 90px);
+      height: calc(100% - 92px);
       overflow-y: scroll;
+      overflow-x: hidden;
       transition: all ease .2s;
     }
 
@@ -603,7 +604,7 @@ $extra-small-screen: '(max-width: 23em)';
 
     @include device($up-to-tablet) {
       width: 100%;
-      padding-right: 0;
+      padding: 0 1rem;
     }
 
     @include device($desktop) {
@@ -626,12 +627,12 @@ $extra-small-screen: '(max-width: 23em)';
     text-align: center;
 
     @include device($up-to-tablet) {
-      margin: 0 auto 3rem;
+      padding: 0 0 3rem;
+      margin: 0 auto;
       width: 100%;
-      padding-right: 0;
 
       &:last-of-type {
-        margin: 2rem auto 2.5rem;
+        padding: 2rem 0 2.5rem;
       }
     }
   }

--- a/src/components/DatePicker/index.vue
+++ b/src/components/DatePicker/index.vue
@@ -1,11 +1,13 @@
 <template>
   <div
-    class="datepicker__wrapper"
-    :class="{
-      'datepicker__wrapper--grid': gridStyle,
-      'datepicker__wrapper--booking': bookings.length > 0,
-      datepicker__fullview: alwaysVisible
-    }"
+    :class="[
+      'datepicker__wrapper',
+      {
+        'datepicker__wrapper--grid': gridStyle,
+        'datepicker__wrapper--booking': bookings.length > 0,
+        datepicker__fullview: alwaysVisible
+      }
+    ]"
     :ref="`DatePicker-${hash}`"
     v-if="show"
   >
@@ -17,8 +19,11 @@
       <i>+</i>
     </div>
     <div
-      class="datepicker__dummy-wrapper"
-      :class="{ 'datepicker__dummy-wrapper--is-active': isOpen }"
+      v-if="!alwaysVisible"
+      :class="[
+        'datepicker__dummy-wrapper',
+        { 'datepicker__dummy-wrapper--is-active': isOpen }
+      ]"
     >
       <date-input
         :i18n="i18n"
@@ -50,44 +55,51 @@
       </svg>
     </div>
     <div
-      class="datepicker"
-      :class="{
-        'datepicker--open': isOpen && !alwaysVisible,
-        'datepicker--closed': !isOpen && !alwaysVisible,
-        'datepicker--right': positionRight
-      }"
+      :class="[
+        'datepicker',
+        {
+          'datepicker--open': isOpen && !alwaysVisible,
+          'datepicker--closed': !isOpen && !alwaysVisible,
+          'datepicker--right': positionRight
+        }
+      ]"
     >
-      <div v-if="isMobile">
+      <div
+        v-if="isOpen && isMobile"
+        :class="[
+          'datepicker__dummy-wrapper datepicker__dummy-wrapper--no-border',
+          { 'datepicker__dummy-wrapper--is-active': isOpen }
+        ]"
+        @click="toggleDatepicker"
+      >
         <div
-          v-if="isOpen"
-          class="datepicker__dummy-wrapper datepicker__dummy-wrapper--no-border"
-          :class="{ 'datepicker__dummy-wrapper--is-active': isOpen }"
-          @click="toggleDatepicker"
-        >
-          <div
-            class="datepicker__input"
-            tabindex="0"
-            :class="{
+          tabindex="0"
+          :class="[
+            'datepicker__input',
+            {
               'datepicker__dummy-input--is-active': isOpen && checkIn == null
-            }"
-            type="button"
-          >
-            {{ `${checkIn ? dateFormater(checkIn) : i18n["check-in"]}` }}
-          </div>
+            }
+          ]"
+          type="button"
+        >
+          {{ `${checkIn ? dateFormater(checkIn) : i18n["check-in"]}` }}
+        </div>
 
-          <div
-            class="datepicker__input"
-            tabindex="0"
-            :class="{
+        <div
+          tabindex="0"
+          :class="[
+            'datepicker__input',
+            {
               'datepicker__dummy-input--is-active':
                 isOpen && checkOut == null && checkIn !== null
-            }"
-            type="button"
-          >
-            {{ `${checkOut ? dateFormater(checkOut) : i18n["check-out"]}` }}
-          </div>
+            }
+          ]"
+          type="button"
+        >
+          {{ `${checkOut ? dateFormater(checkOut) : i18n["check-out"]}` }}
         </div>
       </div>
+
       <div v-if="isOpen || alwaysVisible" class="datepicker__inner">
         <div class="datepicker__header" v-if="isDesktop">
           <button
@@ -107,9 +119,12 @@
             :tabindex="isOpen ? 0 : -1"
           />
         </div>
+
         <div
-          class="datepicker__months"
-          :class="{ 'datepicker__months--full': showSingleMonth }"
+          :class="[
+            'datepicker__months',
+            { 'datepicker__months--full': showSingleMonth }
+          ]"
           v-if="isDesktop || alwaysVisible"
         >
           <div
@@ -174,15 +189,20 @@
             </div>
           </div>
         </div>
+
         <div
           v-if="isMobile && isOpen && !alwaysVisible"
-          :class="{ 'show-tooltip': showCustomTooltip && hoveringTooltip }"
+          :class="[
+            'h-full',
+            { 'show-tooltip': showCustomTooltip && hoveringTooltip }
+          ]"
         >
           <div class="datepicker__tooltip--mobile" v-if="hoveringTooltip">
             <template v-if="customTooltipMessage">
               {{ cleanString(customTooltipMessage) }}
             </template>
           </div>
+
           <div class="datepicker__week-row">
             <div
               class="datepicker__week-name"
@@ -194,6 +214,7 @@
               {{ dayName }}
             </div>
           </div>
+
           <div class="datepicker__months" ref="swiperWrapper">
             <div
               ref="datepickerMonth"
@@ -204,17 +225,6 @@
               <p class="datepicker__month-name">
                 {{ getMonth(months[n].days[15].date) }}
               </p>
-              <div class="datepicker__week-row" v-if="isDesktop">
-                <div
-                  class="datepicker__week-name"
-                  v-for="(dayName, datePickerIndex) in i18n['day-names']"
-                  :key="
-                    `datepicker__month-name-datepicker__week-name-${datePickerIndex}`
-                  "
-                >
-                  {{ dayName }}
-                </div>
-              </div>
               <div class="container-square">
                 <div
                   class="square"
@@ -601,25 +611,23 @@ export default {
         if (value) {
           body.style.overflow = "hidden";
 
-          if (this.checkIn && this.checkOut) {
-            this.$nextTick(() => {
-              if (this.$refs) {
-                const { swiperWrapper } = this.$refs;
-                const currentSelectionIndex = this.checkOut
-                  ? this.getMonthDiff(new Date(), this.checkOut)
-                  : 0;
+          this.$nextTick(() => {
+            if (this.checkIn && this.checkOut) {
+              const { swiperWrapper } = this.$refs;
+              const currentSelectionIndex = this.checkOut
+                ? this.getMonthDiff(new Date(), this.checkOut)
+                : 0;
 
-                if (currentSelectionIndex > 1) {
-                  const heightOfCubeDate = 50;
-                  const currentMonthOffset =
-                    this.$refs.datepickerMonth[currentSelectionIndex - 1]
-                      .offsetTop - heightOfCubeDate;
+              if (currentSelectionIndex > 1) {
+                const heightOfCubeDate = 50;
+                const currentMonthOffset =
+                  this.$refs.datepickerMonth[currentSelectionIndex - 1]
+                    .offsetTop - heightOfCubeDate;
 
-                  swiperWrapper.scrollTop = currentMonthOffset;
-                }
+                swiperWrapper.scrollTop = currentMonthOffset;
               }
-            });
-          }
+            }
+          });
         } else {
           body.style.overflow = "";
         }

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -26,7 +26,7 @@
     </div>
 
     <BookingBullet
-      v-if="currentBooking && belongsToThisMonth && !isDisabled"
+      v-if="currentBooking && !isDisabled"
       :currentBooking="currentBooking"
       :duplicateBookingDates="duplicateBookingDates"
       :formatDate="formatDate"
@@ -52,10 +52,6 @@ export default {
     },
     activeMonthIndex: {
       type: Number
-    },
-    belongsToThisMonth: {
-      type: Boolean,
-      default: false
     },
     checkIn: {
       type: Date
@@ -282,142 +278,134 @@ export default {
       return "";
     },
     dayClass() {
-      if (this.belongsToThisMonth) {
-        // If the calendar has a minimum number of nights && !checkOut
-        const nextValidDate = this.addDays(this.checkIn, this.minNightCount);
-        const isDateAfterMinimumDuration =
-          this.getDayDiff(this.hoveringDate, nextValidDate) <= 0;
+      // If the calendar has a minimum number of nights && !checkOut
+      const nextValidDate = this.addDays(this.checkIn, this.minNightCount);
+      const isDateAfterMinimumDuration =
+        this.getDayDiff(this.hoveringDate, nextValidDate) <= 0;
 
-        if (
-          !isDateAfterMinimumDuration &&
-          !this.checkOut &&
-          !this.isDisabled &&
-          this.compareDay(this.date, this.checkIn) === 1 &&
-          this.minNightCount > 0 &&
-          this.compareDay(
-            this.date,
-            this.addDays(this.checkIn, this.minNightCount)
-          ) === -1
-        ) {
-          return "datepicker__month-day--valid datepicker__month-day--disabled datepicker__month-day--not-allowed minimumDurationUnvalidDay";
-        }
+      if (
+        !isDateAfterMinimumDuration &&
+        !this.checkOut &&
+        !this.isDisabled &&
+        this.compareDay(this.date, this.checkIn) === 1 &&
+        this.minNightCount > 0 &&
+        this.compareDay(
+          this.date,
+          this.addDays(this.checkIn, this.minNightCount)
+        ) === -1
+      ) {
+        return "datepicker__month-day--valid datepicker__month-day--disabled datepicker__month-day--not-allowed minimumDurationUnvalidDay";
+      }
 
-        // Current Day
-        if (
-          !this.isDisabled &&
-          this.date === this.hoveringDate &&
-          this.checkIn !== null &&
-          this.checkOut == null
-        ) {
-          return "datepicker__month-day--selected datepicker__month-day--hovering currentDay";
-        }
+      // Current Day
+      if (
+        !this.isDisabled &&
+        this.date === this.hoveringDate &&
+        this.checkIn !== null &&
+        this.checkOut == null
+      ) {
+        return "datepicker__month-day--selected datepicker__month-day--hovering currentDay";
+      }
 
-        // Highlight the selected dates and prevent the user from selecting
-        // the same date for checkout and checkin
-        if (
-          this.checkIn !== null &&
-          this.dateFormater(this.checkIn) === this.dateFormater(this.date)
-        ) {
-          if (this.minNightCount === 0) {
-            return "datepicker__month-day--first-day-selected checkIn";
-          }
-
-          // Good
-          return "datepicker__month-day--disabled datepicker__month-day--first-day-selected checkIn";
-        }
-
-        // Checkout day
-        if (this.checkOut !== null) {
-          if (
-            this.dateFormater(this.checkOut) === this.dateFormater(this.date)
-          ) {
-            if (this.halfDayClass) {
-              return `datepicker__month-day--disabled datepicker__month-day--last-day-selected ${this.halfDayClass} checkOut`;
-            }
-
-            return "datepicker__month-day--disabled datepicker__month-day--last-day-selected checkOut";
-          }
-        }
-
-        // Only highlight dates that are not disabled
-        if (this.isHighlighted && !this.isDisabled) {
-          if (
-            this.options.disabledDaysOfWeek.some(
-              i => i === fecha.format(this.date, "dddd")
-            )
-          ) {
-            return "datepicker__month-day--selected datepicker__month-day--disabled afterMinimumDurationValidDay";
-          }
-
-          if (
-            Object.keys(this.checkInPeriod).length > 0 &&
-            this.checkInPeriod.periodType.includes("weekly") &&
-            this.hoveringDate &&
-            ((this.checkInPeriod.periodType === "weekly_by_saturday" &&
-              this.hoveringDate.getDay() === 6) ||
-              (this.checkInPeriod.periodType === "weekly_by_sunday" &&
-                this.hoveringDate.getDay() === 0)) &&
-            this.isDateLessOrEquals(this.date, this.hoveringDate)
-          ) {
-            // If currentPeriod has a minimumDuration 1
-            if (this.checkInPeriod.minimumDuration === 1) {
-              return "datepicker__month-day--selected afterMinimumDurationValidDay";
-            }
-
-            // If currentPeriod has a minimumDuration superior to 1
-            if (
-              this.getDayDiff(
-                this.hoveringDate,
-                this.checkInPeriod.nextValidDate
-              ) <= 0
-            ) {
-              return "datepicker__month-day--selected afterMinimumDurationValidDay";
-            }
-          } else if (
-            Object.keys(this.checkInPeriod).length > 0 &&
-            this.checkInPeriod.periodType === "nightly" &&
-            this.hoveringDate &&
-            this.hoveringPeriod.periodType.includes("weekly") &&
-            ((this.hoveringPeriod.periodType === "weekly_by_saturday" &&
-              this.hoveringDate.getDay() === 6) ||
-              (this.hoveringPeriod.periodType === "weekly_by_sunday" &&
-                this.hoveringDate.getDay() === 0 &&
-                this.isDateLessOrEquals(this.date, this.hoveringDate)))
-          ) {
-            return "datepicker__month-day--selected afterMinimumDurationValidDay";
-          }
-
-          if (
-            this.hoveringPeriod.periodType === "nightly" &&
-            this.isDateLessOrEquals(this.date, this.hoveringDate)
-          ) {
-            return "datepicker__month-day--selected afterMinimumDurationValidDay";
-          }
-
-          if (this.checkIn && this.checkOut) {
-            return "datepicker__month-day--selected";
-          }
+      // Highlight the selected dates and prevent the user from selecting
+      // the same date for checkout and checkin
+      if (
+        this.checkIn !== null &&
+        this.dateFormater(this.checkIn) === this.dateFormater(this.date)
+      ) {
+        if (this.minNightCount === 0) {
+          return "datepicker__month-day--first-day-selected checkIn";
         }
 
         // Good
+        return "datepicker__month-day--disabled datepicker__month-day--first-day-selected checkIn";
+      }
+
+      // Checkout day
+      if (this.checkOut !== null) {
+        if (this.dateFormater(this.checkOut) === this.dateFormater(this.date)) {
+          if (this.halfDayClass) {
+            return `datepicker__month-day--disabled datepicker__month-day--last-day-selected ${this.halfDayClass} checkOut`;
+          }
+
+          return "datepicker__month-day--disabled datepicker__month-day--last-day-selected checkOut";
+        }
+      }
+
+      // Only highlight dates that are not disabled
+      if (this.isHighlighted && !this.isDisabled) {
         if (
-          this.isDisabled ||
           this.options.disabledDaysOfWeek.some(
             i => i === fecha.format(this.date, "dddd")
           )
         ) {
-          return "datepicker__month-day--disabled";
+          return "datepicker__month-day--selected datepicker__month-day--disabled afterMinimumDurationValidDay";
         }
-      } else if (!this.belongsToThisMonth) {
-        // Good
-        return "datepicker__month-day--hidden";
+
+        if (
+          Object.keys(this.checkInPeriod).length > 0 &&
+          this.checkInPeriod.periodType.includes("weekly") &&
+          this.hoveringDate &&
+          ((this.checkInPeriod.periodType === "weekly_by_saturday" &&
+            this.hoveringDate.getDay() === 6) ||
+            (this.checkInPeriod.periodType === "weekly_by_sunday" &&
+              this.hoveringDate.getDay() === 0)) &&
+          this.isDateLessOrEquals(this.date, this.hoveringDate)
+        ) {
+          // If currentPeriod has a minimumDuration 1
+          if (this.checkInPeriod.minimumDuration === 1) {
+            return "datepicker__month-day--selected afterMinimumDurationValidDay";
+          }
+
+          // If currentPeriod has a minimumDuration superior to 1
+          if (
+            this.getDayDiff(
+              this.hoveringDate,
+              this.checkInPeriod.nextValidDate
+            ) <= 0
+          ) {
+            return "datepicker__month-day--selected afterMinimumDurationValidDay";
+          }
+        } else if (
+          Object.keys(this.checkInPeriod).length > 0 &&
+          this.checkInPeriod.periodType === "nightly" &&
+          this.hoveringDate &&
+          this.hoveringPeriod.periodType.includes("weekly") &&
+          ((this.hoveringPeriod.periodType === "weekly_by_saturday" &&
+            this.hoveringDate.getDay() === 6) ||
+            (this.hoveringPeriod.periodType === "weekly_by_sunday" &&
+              this.hoveringDate.getDay() === 0 &&
+              this.isDateLessOrEquals(this.date, this.hoveringDate)))
+        ) {
+          return "datepicker__month-day--selected afterMinimumDurationValidDay";
+        }
+
+        if (
+          this.hoveringPeriod.periodType === "nightly" &&
+          this.isDateLessOrEquals(this.date, this.hoveringDate)
+        ) {
+          return "datepicker__month-day--selected afterMinimumDurationValidDay";
+        }
+
+        if (this.checkIn && this.checkOut) {
+          return "datepicker__month-day--selected";
+        }
+      }
+
+      // Good
+      if (
+        this.isDisabled ||
+        this.options.disabledDaysOfWeek.some(
+          i => i === fecha.format(this.date, "dddd")
+        )
+      ) {
+        return "datepicker__month-day--disabled";
       }
 
       if (this.halfDayClass) {
         return `${this.halfDayClass}`;
       }
 
-      // Good
       return "datepicker__month-day--valid";
     },
     checkinCheckoutClass() {
@@ -448,11 +436,7 @@ export default {
       }
 
       if (currentPeriod) {
-        if (
-          currentPeriod.periodType === "nightly" &&
-          this.belongsToThisMonth &&
-          !this.isDisabled
-        ) {
+        if (currentPeriod.periodType === "nightly" && !this.isDisabled) {
           if (
             ((!this.checkIn && !this.checkOut) ||
               (this.checkIn && this.checkOut)) &&
@@ -503,12 +487,7 @@ export default {
       return this.dateFormater(this.date);
     },
     tabIndex() {
-      if (
-        !this.isOpen ||
-        !this.belongsToThisMonth ||
-        this.isDisabled ||
-        !this.isClickable()
-      ) {
+      if (!this.isOpen || this.isDisabled || !this.isClickable()) {
         return -1;
       }
 
@@ -560,7 +539,6 @@ export default {
           this.showCustomTooltip && this.date === this.hoveringDate;
         const showDefaultTooltip =
           !this.isDisabled &&
-          this.belongsToThisMonth &&
           this.date === this.hoveringDate &&
           this.tooltipMessageDisplay.length > 0 &&
           this.checkIn !== null &&

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -19,9 +19,6 @@
     >
       <div class="datepicker__month-day-wrapper">
         <span>{{ dayNumber }}</span>
-        <strong v-if="showPrice && dayPrice">
-          {{ dayPrice }}
-        </strong>
       </div>
     </div>
 
@@ -46,15 +43,17 @@ export default {
     BookingBullet
   },
   props: {
+    activeMonthIndex: {
+      type: Number,
+      default: 0
+    },
     bookings: {
       type: Array,
       default: () => []
     },
-    activeMonthIndex: {
-      type: Number
-    },
     checkIn: {
-      type: Date
+      type: Date,
+      default: new Date()
     },
     checkIncheckOutHalfDay: {
       type: Object,
@@ -65,10 +64,12 @@ export default {
       default: () => ({})
     },
     checkOut: {
-      type: Date
+      type: Date,
+      default: new Date()
     },
     date: {
-      type: Date
+      type: Date,
+      default: new Date()
     },
     disableCheckoutOnCheckin: {
       type: Boolean,
@@ -93,6 +94,10 @@ export default {
       type: Object,
       default: () => ({})
     },
+    isDesktop: {
+      type: Boolean,
+      required: false
+    },
     isOpen: {
       type: Boolean,
       required: true
@@ -102,7 +107,8 @@ export default {
       default: 0
     },
     nextDisabledDate: {
-      type: [Date, Number, String]
+      type: [Date, Number, String],
+      default: new Date()
     },
     nextPeriodDisableDates: {
       type: Array,
@@ -118,10 +124,6 @@ export default {
     showCustomTooltip: {
       default: false,
       type: Boolean
-    },
-    showPrice: {
-      type: Boolean,
-      default: false
     },
     sortedDisabledDates: {
       type: Array,
@@ -175,27 +177,6 @@ export default {
     },
     dayNumber() {
       return fecha.format(this.date, "D");
-    },
-    dayPrice() {
-      let currentDate = null;
-
-      this.sortedPeriodDates.forEach(d => {
-        if (
-          this.validateDateBetweenTwoDates(d.startAt, d.endAt, this.formatDate)
-        ) {
-          currentDate = d;
-        }
-      });
-
-      if (currentDate) {
-        if (currentDate.periodType === "nightly") {
-          return currentDate.price;
-        }
-
-        return Math.round(currentDate.price / 7);
-      }
-
-      return "";
     },
     halfDayClass() {
       if (Object.keys(this.checkIncheckOutHalfDay).length > 0) {
@@ -299,6 +280,7 @@ export default {
 
       // Current Day
       if (
+        this.isDesktop &&
         !this.isDisabled &&
         this.date === this.hoveringDate &&
         this.checkIn !== null &&
@@ -343,6 +325,7 @@ export default {
         }
 
         if (
+          this.isDesktop &&
           Object.keys(this.checkInPeriod).length > 0 &&
           this.checkInPeriod.periodType.includes("weekly") &&
           this.hoveringDate &&
@@ -367,6 +350,7 @@ export default {
             return "datepicker__month-day--selected afterMinimumDurationValidDay";
           }
         } else if (
+          this.isDesktop &&
           Object.keys(this.checkInPeriod).length > 0 &&
           this.checkInPeriod.periodType === "nightly" &&
           this.hoveringDate &&
@@ -381,6 +365,7 @@ export default {
         }
 
         if (
+          this.isDesktop &&
           this.hoveringPeriod.periodType === "nightly" &&
           this.isDateLessOrEquals(this.date, this.hoveringDate)
         ) {

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -6,9 +6,9 @@
       v-if="showTooltip && options.hoveringTooltip"
     />
     <div
-      class="datepicker__month-day"
       @click.prevent.stop="dayClicked($event, date)"
       :class="[
+        'datepicker__month-day',
         dayClass,
         checkinCheckoutClass,
         bookingClass,
@@ -19,11 +19,12 @@
     >
       <div class="datepicker__month-day-wrapper">
         <span>{{ dayNumber }}</span>
-        <strong v-if="showPrice && dayPrice" style="font-size: 10px">
+        <strong v-if="showPrice && dayPrice">
           {{ dayPrice }}
         </strong>
       </div>
     </div>
+
     <BookingBullet
       v-if="currentBooking && belongsToThisMonth && !isDisabled"
       :currentBooking="currentBooking"


### PR DESCRIPTION
* Review the pagination on mobile side, use the same logique on desktop side increment an index and create month only when the index is superior to countOfMobileMonth / countOfDesktopMonth
* Review some style of mobile calendar
* Add v-if on `<Day></Day>` when `day.belongsToThisMonth === false` to avoid 10 day per month load for nothing at all
* Increase the performance on mobile side
* Sort props by ASC
* Add `v-if="isMobile"` on computed when is not triggered on mobile