### PR TITLE
remove duplicate day, refacto style + fix pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,15 @@ https://github.com/joffreyBerrier/vue-hotel-datepicker/projects/1?fullscreen=tru
 * Add a range of bookings #65
 * Review the pagination on mobile side:
 -- remove pagination with scroll add a button for more smooth
--- use the same logique on desktop side increment an index and create month only when the index is superior to countOfMobileMonth / countOfDesktopMonth
+-- use the same logique on desktop side increment an index and create month only when the index is superior to `countOfMobileMonth` / `countOfDesktopMonth`
 * Review some style of mobile calendar
 * Add v-if on when day.belongsToThisMonth === false to avoid 10 day per month load for nothing at all
 * Increase the performance on mobile side
+* Remove duplicate `<Day />` unify pagination for desktop and mobile
+* Create a `<DatePickerWeekRow/> component for not duplicate content
+* Add a `countOfMonthAlreadyCreate`props for generate x month on a created
+* Remove duplicate useless `<baseInput />`
+* Refacto the style of `<baseInput />`
 ------------
 
 ## What I will improve
@@ -426,14 +431,20 @@ Example:
 - Type: `Number`
 - Default: `10`
 
-Number of month you want to show on mobile
+Number of month you want to display on mobile
 
 ### countOfDesktopMonth
 
 - Type: `Number`
 - Default: `2`
 
-Number of month you want to show on desktop
+Number of month you want to display on desktop
+
+### countOfMonthAlreadyCreate
+- Type: `Number`
+- Default: `12`
+
+Number of month you want to have already created, the next month `countOfMonthAlreadyCreate` + 1 will be created directly after you click on pagination button
 
 ## API
 ⚠️ In order to open/close the datepicker from an external element, such as a button make sure to set `closeDatepickerOnClickOutside` to false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-hotel-datepicker2",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Joffrey Berrier - Origin created by krystalcampioni",
   "description": "Vue date range picker component fork of vue-hotel-datepicker create by krystalcampioni",
   "main": "dist/vueHotelDatepicker2.common.js",

--- a/src/App.vue
+++ b/src/App.vue
@@ -351,95 +351,22 @@
 
       <div class="box">
         <h3>Custom date format with i18n (e.g.: pt-PT)</h3>
-        <DatePicker
-          :minNights="0"
-          :singleDateSelection="true"
-          format="MMMM D"
-          :i18n="ptPT"
-        />
+        <DatePicker format="MMMM D" :i18n="ptPT" />
       </div>
 
       <div class="box">
         <h3>Change the first day of the week to Monday</h3>
-        <DatePicker
-          :i18n="{
-            night: 'Night',
-            nights: 'Nights',
-            'day-names': ['Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
-            'check-in': 'Check-in',
-            'check-out': 'Check-Out',
-            'month-names': [
-              'January',
-              'February',
-              'March',
-              'April',
-              'May',
-              'June',
-              'July',
-              'August',
-              'September',
-              'October',
-              'November',
-              'December'
-            ]
-          }"
-          :firstDayOfWeek="1"
-        />
+        <DatePicker :firstDayOfWeek="1" />
       </div>
 
       <div class="box">
         <h3>Set checkIn value</h3>
-        <DatePicker
-          :i18n="{
-            night: 'Night',
-            nights: 'Nights',
-            'day-names': ['Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
-            'check-in': 'Check-in',
-            'check-out': 'Check-Out',
-            'month-names': [
-              'January',
-              'February',
-              'March',
-              'April',
-              'May',
-              'June',
-              'July',
-              'August',
-              'September',
-              'October',
-              'November',
-              'December'
-            ]
-          }"
-          :firstDayOfWeek="1"
-          :checkInValue="new Date()"
-        />
+        <DatePicker :firstDayOfWeek="1" :checkInValue="new Date()" />
       </div>
 
       <div class="box">
         <h3>Set checkOut value</h3>
         <DatePicker
-          :i18n="{
-            night: 'Night',
-            nights: 'Nights',
-            'day-names': ['Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
-            'check-in': 'Check-in',
-            'check-out': 'Check-Out',
-            'month-names': [
-              'January',
-              'February',
-              'March',
-              'April',
-              'May',
-              'June',
-              'July',
-              'August',
-              'September',
-              'October',
-              'November',
-              'December'
-            ]
-          }"
           :firstDayOfWeek="1"
           :checkInValue="new Date()"
           :checkOutValue="
@@ -455,27 +382,6 @@
       <div class="box">
         <h3>Event CheckIn</h3>
         <DatePicker
-          :i18n="{
-            night: 'Night',
-            nights: 'Nights',
-            'day-names': ['Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
-            'check-in': 'Check-in',
-            'check-out': 'Check-Out',
-            'month-names': [
-              'January',
-              'February',
-              'March',
-              'April',
-              'May',
-              'June',
-              'July',
-              'August',
-              'September',
-              'October',
-              'November',
-              'December'
-            ]
-          }"
           @check-in-changed="checkInChanged($event)"
           @check-out-changed="checkOutChanged($event)"
         />
@@ -501,8 +407,8 @@ export default {
         night: "Noite",
         nights: "Noites",
         "day-names": ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"],
-        "check-in": "Chegada",
-        "check-out": "Partida",
+        "check-in": "Partida",
+        "check-out": "Chegada",
         "month-names": [
           "Janeiro",
           "Fevereiro",
@@ -528,8 +434,8 @@ export default {
         weeks: "semanas"
       },
       frFR: {
-        "check-in": "Départ",
-        "check-out": "Arrivée",
+        "check-in": "Arrivée",
+        "check-out": "Départ",
         "day-names": ["lu", "ma", "me", "je", "ve", "sa", "di"],
         "month-names": [
           "Janvier",
@@ -673,8 +579,6 @@ export default {
   },
   methods: {
     renderNextMonth() {
-      console.log("render next month");
-
       this.dynamicDisabledDates = [
         "2021-04-15",
         "2021-04-16",

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -1,8 +1,6 @@
 <template>
   <div
     :class="['datepicker__input', inputClass]"
-    @click="toggleDatepicker"
-    @keyup.enter.stop.prevent="toggleDatepicker"
     data-qa="datepickerInput"
     :tabindex="tabIndex"
   >
@@ -32,10 +30,6 @@ export default {
     singleDaySelection: {
       type: Boolean,
       default: false
-    },
-    toggleDatepicker: {
-      type: Function,
-      required: true
     }
   },
   computed: {

--- a/src/components/DatePicker/index.scss
+++ b/src/components/DatePicker/index.scss
@@ -141,7 +141,7 @@ $extra-small-screen: '(max-width: 23em)';
   font-size: 16px;
   line-height: 14px;
   overflow: hidden;
-  top: 48px;
+  top: 50px;
   position: absolute;
   z-index: 999;
 
@@ -200,14 +200,14 @@ $extra-small-screen: '(max-width: 23em)';
     }
   }
 
+  &__dummy-wrapper {
+    background: $white url('calendar_icon.regular.svg') no-repeat 17px center / 16px;
+  }
+
   &__wrapper {
     position: relative;
-    display: inline-block;
-    width: 100%;
-    height: 48px;
-    background: $white url('calendar_icon.regular.svg') no-repeat 17px center / 16px;
 
-    &--grid .square .datepicker__month-day {
+    .square .datepicker__month-day {
       border: 1px solid $light-gray;
       margin: -1px 0 0 -1px;
     }
@@ -243,7 +243,6 @@ $extra-small-screen: '(max-width: 23em)';
     .datepicker__months {
       position: static;
       margin: 0;
-      width: auto;
 
       &::before {
         display: none;
@@ -255,13 +254,24 @@ $extra-small-screen: '(max-width: 23em)';
   &__input {
     background: transparent;
     height: 48px;
+    display: flex;
+    align-items: center;
     color: $primary-text-color;
     font-size: 12px;
     outline: none;
-    padding: 4px 30px 2px;
-    width: 100%;
     word-spacing: 5px;
     border: 0;
+
+    &--first {
+      padding-left: 50px;
+      &:after {
+        position: relative;
+        content: "→";
+        font-family: arial;
+        font-size: 1.2rem;
+        padding: 0 .75rem;
+      }
+    }
 
     @include focusStyle();
 
@@ -278,7 +288,7 @@ $extra-small-screen: '(max-width: 23em)';
     cursor: pointer;
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    align-items: center;
     width: 100%;
     height: 100%;
 
@@ -288,6 +298,7 @@ $extra-small-screen: '(max-width: 23em)';
 
     &--no-border.datepicker__dummy-wrapper {
       border: 0;
+      border-bottom: 1px solid #f5f7f8;
     }
 
     &--is-active {
@@ -297,23 +308,10 @@ $extra-small-screen: '(max-width: 23em)';
 
   &__input {
     color: $primary-text-color;
-    padding-top: 0;
     font-size: $font-small;
-    height: 48px;
-    line-height: 48px;
-    text-align: left;
-    text-indent: 5px;
-    width: calc(50% + 4px);
 
     @include device($phone) {
-      text-indent: 0;
       text-align: center;
-    }
-
-    &:first-child {
-      background: transparent url('ic-arrow-right-datepicker.regular.svg') no-repeat right center / 8px;
-      width: calc(50% - 4px);
-      text-indent: 20px;
     }
 
     &--is-active {
@@ -571,7 +569,7 @@ $extra-small-screen: '(max-width: 23em)';
     }
 
     @include device($up-to-tablet) {
-      height: calc(100% - 92px);
+      height: calc(100% - 90px);
       overflow-y: scroll;
       overflow-x: hidden;
       transition: all ease .2s;
@@ -595,9 +593,14 @@ $extra-small-screen: '(max-width: 23em)';
     &--full {
       width: 100%;
 
-      .datepicker__month {
-        width: 470px;
-        padding: 0
+      .datepicker__months {
+        width: 100%;
+      }
+
+      @include device($up-to-tablet) {
+        .datepicker__month {
+          width: 100%;
+        }
       }
 
       &::before {
@@ -662,6 +665,12 @@ $extra-small-screen: '(max-width: 23em)';
       align-items: center;
       margin: 0;
       border-bottom: 1px solid rgba(245, 247, 248, 100);
+    }
+
+    &--always-visible {
+      @include device($up-to-tablet) {
+        border: 0;
+      }
     }
   }
 
@@ -839,10 +848,4 @@ $extra-small-screen: '(max-width: 23em)';
       width: calc(50% - 19px);
     }
   }
-}
-
-
-// Tailwind style
-.h-full {
-  height: 100%
 }

--- a/src/components/DatePickerWeekRow.vue
+++ b/src/components/DatePickerWeekRow.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="datepicker__week-row">
+    <div
+      class="datepicker__week-name"
+      v-for="(dayName, datePickerWeekIndexMobile) in dayNames"
+      :key="datepickerWeekKey + datePickerWeekIndexMobile"
+    >
+      {{ dayName }}
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "DatePickerWeekRow",
+  props: {
+    datepickerWeekKey: {
+      type: Number,
+      default: 0
+    },
+    dayNames: {
+      type: Array,
+      required: true
+    }
+  }
+};
+</script>


### PR DESCRIPTION
* Remove duplicate `<Day />` unify pagination for desktop and mobile
* Create a `<DatePickerWeekRow/> component for not duplicate content
* Add a `countOfMonthAlreadyCreate`props for generate x month on a created
* Remove duplicate useless `<baseInput />`
* Refacto the style of `<baseInput />`

Screenshots

<img width="1014" alt="Capture d’écran 2021-04-22 à 11 58 04" src="https://user-images.githubusercontent.com/26119557/115695388-0f13a400-a362-11eb-9198-43a40dadf3cb.png">

<img width="1016" alt="Capture d’écran 2021-04-22 à 11 57 59" src="https://user-images.githubusercontent.com/26119557/115695394-1044d100-a362-11eb-829a-3d7a19018444.png">

<img width="366" alt="Capture d’écran 2021-04-22 à 11 57 54" src="https://user-images.githubusercontent.com/26119557/115695396-10dd6780-a362-11eb-9d55-01155bc5306f.png">

<img width="349" alt="Capture d’écran 2021-04-22 à 11 57 50" src="https://user-images.githubusercontent.com/26119557/115695400-120e9480-a362-11eb-846d-839cf7e4c332.png">
