### PR TITLE
fix(customTooltipHalfday): dont show customTooltipHalfday when

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-hotel-datepicker2",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": "Joffrey Berrier - Origin created by krystalcampioni",
   "description": "Vue date range picker component fork of vue-hotel-datepicker create by krystalcampioni",
   "main": "dist/vueHotelDatepicker2.common.js",

--- a/src/components/DatePicker/index.vue
+++ b/src/components/DatePicker/index.vue
@@ -1156,8 +1156,19 @@ export default {
     createHalfDayTooltip(date) {
       this.customTooltipHalfday = "";
       const formatedHoveringDate = this.dateFormater(date);
+      let nextBookableDate = null;
 
-      if (this.checkIncheckOutHalfDay[formatedHoveringDate]) {
+      if (this.checkIn) {
+        nextBookableDate = this.addDays(
+          this.checkIn,
+          this.checkInPeriod.minimumDuration
+        );
+      }
+
+      if (
+        this.checkIncheckOutHalfDay[formatedHoveringDate] &&
+        !this.isDateBefore(date, nextBookableDate)
+      ) {
         this.showCustomTooltip = true;
 
         if (this.checkIncheckOutHalfDay[formatedHoveringDate].checkIn) {


### PR DESCRIPTION
<img width="1068" alt="Capture d’écran, le 2022-01-20 à 15 08 02" src="https://user-images.githubusercontent.com/26119557/150354188-73777e00-cf5b-4234-a517-ee00cbd51b1a.png">

Don't show the `customTooltipHalfday` when the day is disabled