### PR TITLE
feat(datepicker): add slots / props hide input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-hotel-datepicker2",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "author": "Joffrey Berrier - Origin created by krystalcampioni",
   "description": "Vue date range picker component fork of vue-hotel-datepicker create by krystalcampioni",
   "main": "dist/vueHotelDatepicker2.common.js",

--- a/src/App.vue
+++ b/src/App.vue
@@ -452,6 +452,45 @@
         />
       </div>
     </div>
+
+    <div class="box">
+      <h3>
+        Custom slot
+      </h3>
+      <DatePicker
+        ref="DatePicker"
+        clickOutsideElementId="clickOutsideElement"
+        :firstDayOfWeek="1"
+        :showYear="true"
+        :format="dateFormat"
+        :lastDateAvailable="lastDateAvailable"
+        :minNights="1"
+        :i18n="frFR"
+        :hoveringTooltip="true"
+        :disableCheckoutOnCheckin="true"
+        :periodDates="periodDates2"
+        :showInputCalendar="false"
+        @renderNextMonth="renderNextMonth"
+      >
+        <template #header-mobile="{ clearSelection, closeMobileDatepicker }">
+          <div>
+            slot header-mobile
+            <span @click="closeMobileDatepicker">icon 1</span>
+            <span @click="clearSelection">icon 2</span>
+          </div>
+        </template>
+
+        <template
+          v-if="screenSize === 'not-desktop'"
+          #content="{ customTooltipMessage }"
+        >
+          <div style="background-color: #C1C1C1; height: 100%">
+            slot content
+            {{ customTooltipMessage }}
+          </div>
+        </template>
+      </DatePicker>
+    </div>
   </div>
 </template>
 
@@ -738,7 +777,8 @@ export default {
       ],
       newCheckInDate: null,
       newCheckOutDate: null,
-      minNights: 3
+      minNights: 3,
+      screenSize: null
     };
   },
   computed: {
@@ -747,6 +787,13 @@ export default {
     },
     lastDateAvailable() {
       return this.addYears(new Date(), 2);
+    }
+  },
+  mounted() {
+    if (window.innerWidth >= 768) {
+      this.screenSize = "desktop";
+    } else {
+      this.screenSize = "not-desktop";
     }
   },
   methods: {
@@ -771,8 +818,8 @@ export default {
     periodSelected(event, checkIn, checkOut) {
       console.log("periodSelected", event, checkIn, checkOut);
     },
-    handleCheckIncheckOutHalfDay(checkIncheckOutHalfDay) {
-      console.log("handleCheckIncheckOutHalfDay", checkIncheckOutHalfDay);
+    handleCheckIncheckOutHalfDay() {
+      console.log("handleCheckIncheckOutHalfDay");
     },
     addYears(dt, n) {
       return new Date(dt.setFullYear(dt.getFullYear() + n));

--- a/src/components/DatePicker/index.scss
+++ b/src/components/DatePicker/index.scss
@@ -769,7 +769,6 @@ $extra-small-screen: '(max-width: 23em)';
       opacity: 0;
       visibility: hidden;
       padding: 0 1rem;
-      border-bottom: 1px solid #d7d9e2;
       border-top: 1px solid #d7d9e2;
       font-size: 14px;
       line-height: 1.4;

--- a/src/components/DatePicker/index.vue
+++ b/src/components/DatePicker/index.vue
@@ -65,7 +65,14 @@
       ]"
     >
       <div v-if="isOpen && isMobile">
+        <slot
+          name="header-mobile"
+          :clearSelection="clearSelection"
+          :closeMobileDatepicker="closeMobileDatepicker"
+        />
+
         <div
+          v-if="showInputCalendar"
           @click="toggleDatepicker"
           :class="[
             'datepicker__dummy-wrapper datepicker__dummy-wrapper--no-border',
@@ -89,12 +96,6 @@
             :is-open="isOpen"
             :single-day-selection="singleDaySelection"
           />
-        </div>
-
-        <div class="datepicker__tooltip--mobile" v-if="hoveringTooltip">
-          <template v-if="customTooltipMessage">
-            {{ cleanString(customTooltipMessage) }}
-          </template>
         </div>
 
         <DatePickerWeekRow
@@ -220,7 +221,18 @@
           </button>
         </div>
 
-        <slot name="content" />
+        <slot
+          name="content"
+          :customTooltipMessage="
+            customTooltipMessage && cleanString(customTooltipMessage)
+          "
+        >
+          <div class="datepicker__tooltip--mobile" v-if="hoveringTooltip">
+            <template v-if="customTooltipMessage">
+              {{ cleanString(customTooltipMessage) }}
+            </template>
+          </div>
+        </slot>
       </div>
     </div>
   </div>
@@ -380,6 +392,10 @@ export default {
     showSingleMonth: {
       type: Boolean,
       default: false
+    },
+    showInputCalendar: {
+      type: Boolean,
+      default: true
     },
     showYear: {
       type: Boolean,


### PR DESCRIPTION
Gestion de slot pour gérer ces 2 cas là.

<img width="164" alt="Capture d’écran 2023-03-20 à 09 49 53" src="https://user-images.githubusercontent.com/7684148/228516492-204a690b-b391-4373-ba36-217f2cfcb4f7.png">
